### PR TITLE
Update PHP version to 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://navjobs.com",
     "license": "MIT",
     "require": {
-        "php" : ">=5.5.0",
+        "php" : ">=7.0.0",
         "illuminate/database": "^5.1",
         "illuminate/events": "^5.1"
     },


### PR DESCRIPTION
The null coalesce operator, introduced in PHP 7, is used on few lines, as in:
https://github.com/navjobs/temporal-models/blob/master/src/Temporal.php#L56