### PR TITLE
Add chainable method to allow updates inline.

### DIFF
--- a/src/Temporal.php
+++ b/src/Temporal.php
@@ -12,7 +12,7 @@ trait Temporal
      *
      * @var bool
      */
-    public $allowUpdating = false;
+    protected $enableUpdates = false;
 
     /**
      * Boot the temporal trait for a model.
@@ -40,7 +40,7 @@ trait Temporal
         });
 
         static::updating(function ($item) {
-            return $item->allowUpdating();
+            return $item->canUpdate();
         });
 
         static::deleting(function ($item) {
@@ -152,10 +152,10 @@ trait Temporal
      * Dirty attributes must only contain valid_end
      *
      */
-    protected function allowUpdating()
+    protected function canUpdate()
     {
-        if ($this->allowUpdating) {
-            return $this->allowUpdating;
+        if ($this->enableUpdates) {
+            return $this->enableUpdates;
         }
 
         $truthChecks = collect([
@@ -186,6 +186,19 @@ trait Temporal
         }
 
         return false;
+    }
+
+    /**
+     * Sets the enableUpdates property in a chainable manner.
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function enableUpdates($status = true)
+    {
+        $this->enableUpdates = $status;
+
+        return $this;
     }
 
     /********************************************************************************

--- a/tests/TemporalTest.php
+++ b/tests/TemporalTest.php
@@ -226,16 +226,14 @@ class TemporalTest extends TestCase
     public function testItCanUpdateIfTheUserHasSpecifiedToAllowUpdates()
     {
         $commission = $this->createCommission();
-        $commission->allowUpdating = true;
         $commission->valid_start = Carbon::now()->addYear();
-        $commission->save();
+        $commission->enableUpdates()->save();
         $commission = $commission->fresh();
 
         $this->assertEquals(Carbon::now()->addYear()->toDateString(), $commission->valid_start->toDateString());
 
         $commission->agent_id = 30;
-        $commission->allowUpdating = true;
-        $commission->save();
+        $commission->enableUpdates()->save();
         $commission = $commission->fresh();
 
         $this->assertEquals(30, $commission->agent_id);

--- a/tests/TemporalTest.php
+++ b/tests/TemporalTest.php
@@ -269,6 +269,72 @@ class TemporalTest extends TestCase
     }
 
     /**
+     * Tests...
+     */
+    public function testItReceivesValidResultsFromValidScope()
+    {
+        TemporalTestCommission::flushEventListeners();
+        collect([
+            [
+                'id' => 5,
+                'agent_id' => 1,
+                'valid_start' => Carbon::now()->subYear(),
+                'valid_end' => Carbon::now(),
+            ],
+            [
+                'id' => 6,
+                'agent_id' => 1,
+                'valid_start' => Carbon::now(),
+                'valid_end' => Carbon::now()->addYear(),
+            ],
+            [
+                'id' => 7,
+                'agent_id' => 1,
+                'valid_start' => Carbon::now()->addYear(),
+                'valid_end' => null,
+            ],
+        ])->each(function ($commission) {
+            TemporalTestCommission::create($commission);
+        });
+        TemporalTestCommission::registerEvents();
+
+        $this->assertEquals(6, TemporalTestCommission::valid()->first()->id);
+    }
+
+    /**
+     * Tests...
+     */
+    public function testItReceivesInvalidResultsFromInvalidScope()
+    {
+        TemporalTestCommission::flushEventListeners();
+        collect([
+            [
+                'id' => 5,
+                'agent_id' => 1,
+                'valid_start' => Carbon::now()->subYear(),
+                'valid_end' => Carbon::now()->subMinute(),
+            ],
+            [
+                'id' => 6,
+                'agent_id' => 1,
+                'valid_start' => Carbon::now(),
+                'valid_end' => Carbon::now()->addYear(),
+            ],
+            [
+                'id' => 7,
+                'agent_id' => 1,
+                'valid_start' => Carbon::now()->addYear(),
+                'valid_end' => null,
+            ],
+        ])->each(function ($commission) {
+            TemporalTestCommission::create($commission);
+        });
+        TemporalTestCommission::registerEvents();
+
+        $this->assertEquals([5, 7], TemporalTestCommission::invalid()->pluck('id')->toArray());
+    }
+
+    /**
      * Helpers...
      */
     protected function createCommission()


### PR DESCRIPTION
I have added a chainable method to allow updates like so:
```
$commission->valid_start = Carbon::now()->addYear();
$commission->enableUpdates()->save();
```

I changed the visibility of the `$enableUpdates`, previously `$allowUpdating`, property to protected as the proposed `enableUpdates()` method is public. I have updated the lines in the test to call `enableUpdates()` accordingly. I  renamed the `allowUpdating()` method as `canUpdate()`.

The `$enableUpdates` property is able to be overridden, set to `true`, to allow updates on a model by default.