### PR TITLE
Fix CircleCI's supported PHP version.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   php:
-    version: 7.0.4
+    version: 7.1.9
 test:
   override:
     - phpunit tests --coverage-clover build/logs/clover.xml


### PR DESCRIPTION
CircleCI was complaining about 7.0.4 being unsupported. If 7.1.9 is a desirable target, can we try this?